### PR TITLE
Add clipboard clear to loop

### DIFF
--- a/ahk-notepad/notepad-bossfight.ahk
+++ b/ahk-notepad/notepad-bossfight.ahk
@@ -31,6 +31,7 @@ function Shake() {
 
 ;Loop label to change transparency and shake window when HP is low enough
 CheckNotepadHP:
+	clipboard = ; Clears the clipboard to prevent paste https://autohotkey.com/docs/misc/Clipboard.htm
 	WinSet, Transparent, numpadHP, ahk_exe notepad.exe
 	if (numpadHP < 200) {
 		Shake()


### PR DESCRIPTION
This prevents the Edit->Paste and RightClick->Paste workarounds to the blocked Ctrl-V Paste.